### PR TITLE
Fix race condition on shutdown event

### DIFF
--- a/src/Mpv.NET/API/MpvEventLoop.cs
+++ b/src/Mpv.NET/API/MpvEventLoop.cs
@@ -5,116 +5,117 @@ using System.Threading.Tasks;
 
 namespace Mpv.NET.API
 {
-	public class MpvEventLoop : IMpvEventLoop, IDisposable
-	{
-		public bool IsRunning { get; private set; }
+    public class MpvEventLoop : IMpvEventLoop, IDisposable
+    {
+        public bool IsRunning { get => isRunning; private set => isRunning = value; }
 
-		public Action<MpvEvent> Callback { get; set; }
+        public Action<MpvEvent> Callback { get; set; }
 
-		public IntPtr MpvHandle
-		{
-			get => mpvHandle;
-			private set
-			{
-				if (value == IntPtr.Zero)
-					throw new ArgumentException("Mpv handle is invalid.");
-
-				mpvHandle = value;
-			}
-		}
-
-		public IMpvFunctions Functions
-		{
-			get => functions;
-			set
-			{
-				Guard.AgainstNull(value);
-
-				functions = value;
-			}
-		}
-
-		private IntPtr mpvHandle;
-		private IMpvFunctions functions;
-
-		private Task eventLoopTask;
-
-		private bool disposed = false;
-
-		public MpvEventLoop(Action<MpvEvent> callback, IntPtr mpvHandle, IMpvFunctions functions)
-		{
-			Callback = callback;
-			MpvHandle = mpvHandle;
-			Functions = functions;
-		}
-
-		public void Start()
-		{
-			Guard.AgainstDisposed(disposed, nameof(MpvEventLoop));
-
-			DisposeEventLoopTask();
-
-			IsRunning = true;
-
-			eventLoopTask = new Task(EventLoopTaskHandler);
-			eventLoopTask.Start();
-		}
-
-		public void Stop()
-		{
-			Guard.AgainstDisposed(disposed, nameof(MpvEventLoop));
-
-			IsRunning = false;
-
-			if (Task.CurrentId == eventLoopTask.Id)
+        public IntPtr MpvHandle
+        {
+            get => mpvHandle;
+            private set
             {
-				return;
+                if (value == IntPtr.Zero)
+                    throw new ArgumentException("Mpv handle is invalid.");
+
+                mpvHandle = value;
+            }
+        }
+
+        public IMpvFunctions Functions
+        {
+            get => functions;
+            set
+            {
+                Guard.AgainstNull(value);
+
+                functions = value;
+            }
+        }
+
+        private IntPtr mpvHandle;
+        private IMpvFunctions functions;
+
+        private Task eventLoopTask;
+
+        private bool disposed = false;
+        private volatile bool isRunning;
+
+        public MpvEventLoop(Action<MpvEvent> callback, IntPtr mpvHandle, IMpvFunctions functions)
+        {
+            Callback = callback;
+            MpvHandle = mpvHandle;
+            Functions = functions;
+        }
+
+        public void Start()
+        {
+            Guard.AgainstDisposed(disposed, nameof(MpvEventLoop));
+
+            DisposeEventLoopTask();
+
+            IsRunning = true;
+
+            eventLoopTask = new Task(EventLoopTaskHandler);
+            eventLoopTask.Start();
+        }
+
+        public void Stop()
+        {
+            Guard.AgainstDisposed(disposed, nameof(MpvEventLoop));
+
+            IsRunning = false;
+
+            if (Task.CurrentId == eventLoopTask.Id)
+            {
+                return;
             }
 
-			// Wake up WaitEvent in the event loop thread
-			// so we can stop it.
-			Functions.Wakeup(mpvHandle);
-			
-			eventLoopTask.Wait();
-		}
+            // Wake up WaitEvent in the event loop thread
+            // so we can stop it.
+            Functions.Wakeup(mpvHandle);
 
-		private void EventLoopTaskHandler()
-		{
-			while (IsRunning)
-			{
-				var eventPtr = Functions.WaitEvent(mpvHandle, Timeout.Infinite);
-				if (eventPtr != IntPtr.Zero)
-				{
-					var @event = MpvMarshal.PtrToStructure<MpvEvent>(eventPtr);
-					if (@event.ID != MpvEventID.None)
-						Callback?.Invoke(@event);
-				}
-			}
-		}
+            eventLoopTask.Wait();
+        }
 
-		private void DisposeEventLoopTask()
-		{
-			eventLoopTask?.Dispose();
-		}
+        private void EventLoopTaskHandler()
+        {
+            while (IsRunning)
+            {
+                var eventPtr = Functions.WaitEvent(mpvHandle, Timeout.Infinite);
+                if (eventPtr != IntPtr.Zero)
+                {
+                    var @event = MpvMarshal.PtrToStructure<MpvEvent>(eventPtr);
+                    if (@event.ID != MpvEventID.None)
+                        Callback?.Invoke(@event);
+                }
+            }
+        }
 
-		public void Dispose()
-		{
-			Dispose(true);
-		}
+        private void DisposeEventLoopTask()
+        {
+            eventLoopTask?.Dispose();
+        }
 
-		protected virtual void Dispose(bool disposing)
-		{
-			if (disposing)
-			{
-				if (!disposed)
-				{
-					Stop();
+        public void Dispose()
+        {
+            Dispose(true);
+        }
 
-					DisposeEventLoopTask();
-				}
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (!disposed)
+                {
+                    Stop();
 
-				disposed = true;
-			}
-		}
-	}
+                    DisposeEventLoopTask();
+                }
+
+                disposed = true;
+            }
+        }
+    }
 }

--- a/src/Mpv.NET/API/MpvEventLoop.cs
+++ b/src/Mpv.NET/API/MpvEventLoop.cs
@@ -66,6 +66,11 @@ namespace Mpv.NET.API
 
 			IsRunning = false;
 
+			if (Task.CurrentId == eventLoopTask.Id)
+            {
+				return;
+            }
+
 			// Wake up WaitEvent in the event loop thread
 			// so we can stop it.
 			Functions.Wakeup(mpvHandle);

--- a/src/Mpv.NET/API/MpvEvents.cs
+++ b/src/Mpv.NET/API/MpvEvents.cs
@@ -140,7 +140,6 @@ namespace Mpv.NET.API
 
 		private void HandleShutdown()
 		{
-			functions.TerminateDestroy(Handle);
 			eventLoop.Stop();
 			Shutdown?.Invoke(this, EventArgs.Empty);
 		}


### PR DESCRIPTION
Closes #28 
When the event loop receives the shutdown event the event loop task
tried to TerminateDestroy the mpv handle and subsequently wait for
itself to finish.
Instead of calling TerminateDestroy in the shutdown event handler, it
relies on the Mpv::Dispose(bool) function to do so.
And the event loops stop functions checks if it's called by it's own
thread to avoid waiting on itself.