### PR TITLE
New Playlist-related features

### DIFF
--- a/src/Mpv.NET/Player/IMpvPlayer.cs
+++ b/src/Mpv.NET/Player/IMpvPlayer.cs
@@ -1,5 +1,6 @@
 ﻿using Mpv.NET.API;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Mpv.NET.Player
@@ -71,6 +72,8 @@ namespace Mpv.NET.Player
 		event EventHandler<MpvPlayerPositionChangedEventArgs> PositionChanged;
 
 		void Load(string path, bool force = false);
+
+		void LoadPlaylist(IEnumerable<string> paths, bool force = false);
 
 		Task SeekAsync(double position, bool relative = false);
 

--- a/src/Mpv.NET/Player/IMpvPlayer.cs
+++ b/src/Mpv.NET/Player/IMpvPlayer.cs
@@ -34,6 +34,8 @@ namespace Mpv.NET.Player
 
 		bool Loop { get; set; }
 
+		bool LoopPlaylist { get; set; }
+
 		bool EndReached { get; }
 
 		TimeSpan Duration { get; }

--- a/src/Mpv.NET/Player/MpvPlayer.cs
+++ b/src/Mpv.NET/Player/MpvPlayer.cs
@@ -196,6 +196,33 @@ namespace Mpv.NET.Player
 		}
 
 		/// <summary>
+		/// Determines whether playlist will loop.
+		/// </summary>
+		public bool LoopPlaylist
+		{
+			get
+			{
+				string stringValue;
+
+				lock (mpvLock)
+				{
+					stringValue = mpv.GetPropertyString("loop-playlist");
+				}
+
+				return stringValue != "no";
+			}
+			set
+			{
+				var stringValue = value ? "inf" : "no";
+
+				lock (mpvLock)
+				{
+					mpv.SetPropertyString("loop-playlist", stringValue);
+				}
+			}
+		}
+
+		/// <summary>
 		/// Indicates whether media has reached end of playback.
 		/// </summary>
 		public bool EndReached

--- a/src/Mpv.NET/Player/MpvPlayer.cs
+++ b/src/Mpv.NET/Player/MpvPlayer.cs
@@ -1,5 +1,6 @@
 ﻿using Mpv.NET.API;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -590,6 +591,39 @@ namespace Mpv.NET.Player
 
 				var loadMethodString = LoadMethodHelper.ToString(loadMethod);
 				mpv.Command("loadfile", path, loadMethodString);
+			}
+		}
+
+		/// <summary>
+		/// Loads a collection of file paths as a playlist into mpv. If called while media is playing,
+		/// the specified media collection will be appended to the playlist. If youtube-dl is enabled,
+		/// this method can be used to load videos from video sites.
+		/// </summary>
+		/// <param name="paths">Paths or URLs to media sources</param>
+		/// <param name="force">If true, will force load the media replacing any currently playing media.</param>
+		public void LoadPlaylist(IEnumerable<string> paths, bool force = false)
+		{
+			Guard.AgainstNull(paths);
+
+			lock (mpvLock)
+			{
+				mpv.SetPropertyString("pause", AutoPlay ? "no" : "yes");
+
+				bool first = true;
+
+				foreach (string path in paths)
+				{
+					var loadMethod = LoadMethod.Append;
+
+					if (first && (!force || !IsPlaying))
+						loadMethod = LoadMethod.Replace;
+
+					var loadMethodString = LoadMethodHelper.ToString(loadMethod);
+
+					mpv.Command("loadfile", path, loadMethodString);
+
+					first = false;
+				}
 			}
 		}
 


### PR DESCRIPTION
For our project, we had to add two methods that are related to playlists.

- New LoadPlaylist method which takes any collection of video paths to prepare a single playlist for playback
- New LoopPlaylist configuration variable which refers to MPV's `loop-playlist` option to be able to loop an entire playlist instead of a single video